### PR TITLE
GitHub Action to build distribution zip file on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+on:
+  release:
+    types:
+      - published
+name: Build & Release
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: php-actions/composer@v6
+      with:
+        php_version: 7.3
+        php_extensions: gd zip
+    - uses: WyriHaximus/github-action-get-previous-tag@v1
+      id: lasttag
+    - uses: thedoctor0/zip-release@master
+      with:
+        type: 'zip'
+        filename: "dues-lookup-${{ steps.lasttag.outputs.tag }}.zip"
+    - uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true
+        omitBodyDuringUpdate: true
+        omitNameDuringUpdate: true
+        omitPrereleaseDuringUpdate: true
+        tag: ${{ steps.lasttag.outputs.tag }}
+        artifacts: "dues-lookup-${{ steps.lasttag.outputs.tag }}.zip"
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/oadueslookup.php
+++ b/oadueslookup.php
@@ -5,7 +5,7 @@
  * Description: Wordpress plugin to use in conjunction with OA LodgeMaster to allow members to look up when they last paid dues
  * Version: 2.1.3
  * Requires at least: 3.0.1
- * Requires PHP: 7.1
+ * Requires PHP: 7.3
  * Author: Dave Miller
  * Author URI: http://twitter.com/justdavemiller
  * Author Email: github@justdave.net


### PR DESCRIPTION
Automatically runs `composer install` and generates the WordPress-ready ZIP file and attaches it to the release when a new release is created in GitHub.

Also updates min PHP to 7.3 because the dependencies already need it