### PR TITLE
Remove deprecation warning on PHP 8.2 for ${var}

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 #### [unreleased]
 
+* PHP 8.2 compatibility fixes
 * Get the description and changelog working in the update/details dialogs. For whatever reason the remote file is only checked if it already exists locally, so the benefit from doing this will take 2 releases to show up. Once it does, the Description and Changes tabs in the plugin details popup will populate correctly.
 
 #### 2.3 / 2022-02-10

--- a/bin/dues-import-processor.php
+++ b/bin/dues-import-processor.php
@@ -102,7 +102,7 @@ foreach ($objWorksheet->getRowIterator() as $row) {
             $wpdb->show_errors();
             ob_start();
             # Make an empty temporary table based on the dues_data table
-            $wpdb->query("CREATE TEMPORARY TABLE ${dbprefix}dues_data_temp (PRIMARY KEY (bsaid)) SELECT * FROM ${dbprefix}dues_data LIMIT 0");
+            $wpdb->query("CREATE TEMPORARY TABLE {$dbprefix}dues_data_temp (PRIMARY KEY (bsaid)) SELECT * FROM {$dbprefix}dues_data LIMIT 0");
             $oadueslookup_last_import = $wpdb->get_var("SELECT DATE_FORMAT(NOW(), '%Y-%m-%d')");
             # re-insert the test data
             oadueslookup_insert_sample_data();
@@ -152,8 +152,8 @@ $treat_errors_as_fatal = false;
 
 if ((!$treat_errors_as_fatal) || (!$error_output)) {
     # delete the contents of the live table and copy the contents of the temp table to it
-    $wpdb->query("TRUNCATE TABLE ${dbprefix}dues_data");
-    $wpdb->query("INSERT INTO ${dbprefix}dues_data SELECT * FROM ${dbprefix}dues_data_temp");
+    $wpdb->query("TRUNCATE TABLE {$dbprefix}dues_data");
+    $wpdb->query("INSERT INTO {$dbprefix}dues_data SELECT * FROM {$dbprefix}dues_data_temp");
 }
 $error_output .= ob_get_clean();
 if ((!$treat_errors_as_fatal) || (!$error_output)) {
@@ -171,4 +171,4 @@ if (!$error_output) {
 $import_status['output'] = ob_get_clean();
 $import_status['status'] = 'completed';
 update_option('oadueslookup_import_status', $import_status);
-update_option('oadueslookup_last_update', $wpdb->get_var("SELECT DATE_FORMAT(MAX(dues_paid_date), '%Y-%m-%d') FROM ${dbprefix}dues_data"));
+update_option('oadueslookup_last_update', $wpdb->get_var("SELECT DATE_FORMAT(MAX(dues_paid_date), '%Y-%m-%d') FROM {$dbprefix}dues_data"));

--- a/includes/user-facing-lookup-page.php
+++ b/includes/user-facing-lookup-page.php
@@ -28,7 +28,7 @@ function oadueslookup_user_page($attr)
     if (isset($_POST['bsaid'])) {
         $bsaid = trim($_POST['bsaid']);
         if (preg_match('/^\d+$/', $bsaid)) {
-            $results = $wpdb->get_row($wpdb->prepare("SELECT max_dues_year, dues_paid_date, level, bsa_reg, bsa_reg_overridden, bsa_verify_date, bsa_verify_status FROM ${dbprefix}dues_data WHERE bsaid = %d", array($bsaid)));
+            $results = $wpdb->get_row($wpdb->prepare("SELECT max_dues_year, dues_paid_date, level, bsa_reg, bsa_reg_overridden, bsa_verify_date, bsa_verify_status FROM {$dbprefix}dues_data WHERE bsaid = %d", array($bsaid)));
             if (!isset($results)) {
                 ?>
 <div class="oalm_dues_bad"><p>Your BSA Member ID <?php echo htmlspecialchars($bsaid) ?> was not found.</p></div>

--- a/oadueslookup.php
+++ b/oadueslookup.php
@@ -92,7 +92,7 @@ function oadueslookup_install()
     // only if it doesn't exist yet. If the columns or indexes need to
     // change it'll need update code (see below).
 
-    $sql = "CREATE TABLE ${dbprefix}dues_data (
+    $sql = "CREATE TABLE {$dbprefix}dues_data (
   bsaid                 INT NOT NULL,
   max_dues_year         VARCHAR(4),
   dues_paid_date        DATE,
@@ -129,18 +129,18 @@ function oadueslookup_install()
 
     if ($installed_version < 2) {
         # Add a column for the Last Audit Date field
-        $wpdb->query("ALTER TABLE ${dbprefix}dues_data ADD COLUMN reg_audit_date DATE");
+        $wpdb->query("ALTER TABLE {$dbprefix}dues_data ADD COLUMN reg_audit_date DATE");
     }
 
     if ($installed_version < 3) {
         # Drop the old registration audit fields for OALM 4.1.2 or below.
-        $wpdb->query("ALTER TABLE ${dbprefix}dues_data DROP COLUMN reg_audit_date");
-        $wpdb->query("ALTER TABLE ${dbprefix}dues_data DROP COLUMN reg_audit_result");
+        $wpdb->query("ALTER TABLE {$dbprefix}dues_data DROP COLUMN reg_audit_date");
+        $wpdb->query("ALTER TABLE {$dbprefix}dues_data DROP COLUMN reg_audit_result");
         # Add the columns for the BSA registration fields in OALM 4.2.0 and above.
-        $wpdb->query("ALTER TABLE ${dbprefix}dues_data ADD COLUMN bsa_reg TINYINT(1)");
-        $wpdb->query("ALTER TABLE ${dbprefix}dues_data ADD COLUMN bsa_reg_overridden TINYINT(1)");
-        $wpdb->query("ALTER TABLE ${dbprefix}dues_data ADD COLUMN bsa_verify_date DATE");
-        $wpdb->query("ALTER TABLE ${dbprefix}dues_data ADD COLUMN bsa_verify_status VARCHAR(50)");
+        $wpdb->query("ALTER TABLE {$dbprefix}dues_data ADD COLUMN bsa_reg TINYINT(1)");
+        $wpdb->query("ALTER TABLE {$dbprefix}dues_data ADD COLUMN bsa_reg_overridden TINYINT(1)");
+        $wpdb->query("ALTER TABLE {$dbprefix}dues_data ADD COLUMN bsa_verify_date DATE");
+        $wpdb->query("ALTER TABLE {$dbprefix}dues_data ADD COLUMN bsa_verify_status VARCHAR(50)");
     }
 
     // insert next database revision update code immediately above this line.
@@ -222,7 +222,7 @@ function oadueslookup_insert_sample_data()
     global $wpdb;
     $dbprefix = $wpdb->prefix . "oalm_";
 
-    $wpdb->query("INSERT INTO ${dbprefix}dues_data_temp " .
+    $wpdb->query("INSERT INTO {$dbprefix}dues_data_temp " .
         "(bsaid,    max_dues_year, dues_paid_date, level,        bsa_reg,   bsa_reg_overridden, bsa_verify_date, bsa_verify_status) VALUES " .
         "('123453','2013',         '2012-11-15',   'Brotherhood','1',       '0',                '1900-01-01',   'BSA ID Not Found'), " .
         "('123454','2014',         '2013-12-28',   'Ordeal',     '1',       '0',                '1900-01-01',   'BSA ID Not Found'), " .
@@ -231,7 +231,7 @@ function oadueslookup_insert_sample_data()
         "('123457','2014',         '2013-12-18',   'Brotherhood','0',       '0',                '1900-01-01',   'BSA ID Found - Data Mismatch'), " .
         "('123458','2013',         '2013-03-15',   'Vigil',      '1',       '0',                '1900-01-01',   'BSA ID Not Found'), " .
         "('123459','2015',         '2014-03-15',   'Ordeal',     '0',       '0',                '1900-01-01',   'Never Run')");
-    $wpdb->query($wpdb->prepare("UPDATE ${dbprefix}dues_data SET bsa_verify_date=%s", get_option('oadueslookup_last_update')));
+    $wpdb->query($wpdb->prepare("UPDATE {$dbprefix}dues_data SET bsa_verify_date=%s", get_option('oadueslookup_last_update')));
 }
 
 function oadueslookup_install_data()
@@ -240,11 +240,11 @@ function oadueslookup_install_data()
     $dbprefix = $wpdb->prefix . "oalm_";
 
     # Make an empty temporary table based on the dues_data table
-    $wpdb->query("CREATE TEMPORARY TABLE ${dbprefix}dues_data_temp SELECT * FROM ${dbprefix}dues_data LIMIT 0");
+    $wpdb->query("CREATE TEMPORARY TABLE {$dbprefix}dues_data_temp SELECT * FROM {$dbprefix}dues_data LIMIT 0");
     # load some sample data into it
     oadueslookup_insert_sample_data();
     # and copy the contents of the temporary table into the real one
-    $wpdb->query("INSERT INTO ${dbprefix}dues_data SELECT * FROM ${dbprefix}dues_data_temp");
+    $wpdb->query("INSERT INTO {$dbprefix}dues_data SELECT * FROM {$dbprefix}dues_data_temp");
 }
 
 # Let admin users know about version 2.1 shortcode migration


### PR DESCRIPTION
PHP has always supported both ${var} and {$var} for embedding variables in strings.  PHP 8.2 has made ${var} throw a deprecation warning, and they intend to make it throw an exception in PHP 8.3, leaving {$var} as the only supported option.
