### PR TITLE
Change BSA to Scouting in import tool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+#### Unreleased changes
+
+* Fix Dues Import to handle new column names from LodgeMaster (they renamed most instances of "BSA" to "Scouting" in the column names).
+
 #### 2.5.1 / 2024-11-22
 
 * Security updates to embedded spreadsheet parser

--- a/bin/dues-import-processor.php
+++ b/bin/dues-import-processor.php
@@ -55,14 +55,14 @@ $objReader->setLoadSheetsOnly(array("All"));
 $objSpreadsheet = $objReader->load($filename);
 $objWorksheet = $objSpreadsheet->getActiveSheet();
 $columnMap = array(
-'BSA ID'                => 'bsaid',
-'Dues Yr.'              => 'max_dues_year',
-'Dues Pd. Dt.'          => 'dues_paid_date',
-'Level'                 => 'level',
-'BSA Reg.'              => 'bsa_reg',
-'BSA Reg. Overidden'    => 'bsa_reg_overridden',
-'BSA Verify Date'       => 'bsa_verify_date',
-'BSA Verify Status'     => 'bsa_verify_status',
+'Member ID'               => 'bsaid',
+'Dues Yr.'                => 'max_dues_year',
+'Dues Pd. Dt.'            => 'dues_paid_date',
+'Level'                   => 'level',
+'Scouting Reg.'           => 'bsa_reg',
+'Scouting Reg. Overidden' => 'bsa_reg_overridden',
+'Scouting Verify Date'    => 'bsa_verify_date',
+'Scouting Verify Status'  => 'bsa_verify_status',
 );
 $complete = 0;
 $rowcount = $objWorksheet->getHighestRow();


### PR DESCRIPTION
LodgeMaster just changed most "BSA" references to be "Scouting" instead, including in column names that get exported for this plugin.

First PR is only going to handle the column name changes in the LodgeMaster export so we can push it out and have the tool not be broken.

A followup PR will handle doing a similar cleanup in our own code to remove our own BSA references.