### PR TITLE
rebrand BSA to Scouting in the code and user-facing pages. Fixes #64

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+#### unreleased changes
+
+* Full rebrand to the new Scouting American terminology.
+* The included membership card sample is still the old one because the one I can download from MyScouting still says BSA on it. As soon as they update it, I'll update the sample graphic.
+
 #### 2.5.3 / 2024-12-09
 
 * Oops, the possible values in the Last Status column changed, too.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 #### unreleased changes
 
-* Full rebrand to the new Scouting American terminology.
+* Full rebrand to the new Scouting America terminology.
 * The included membership card sample is still the old one because the one I can download from MyScouting still says BSA on it. As soon as they update it, I'll update the sample graphic.
 
 #### 2.5.3 / 2024-12-09

--- a/bin/dues-import-processor.php
+++ b/bin/dues-import-processor.php
@@ -55,14 +55,14 @@ $objReader->setLoadSheetsOnly(array("All"));
 $objSpreadsheet = $objReader->load($filename);
 $objWorksheet = $objSpreadsheet->getActiveSheet();
 $columnMap = array(
-'Member ID'               => 'bsaid',
+'Member ID'               => 'memberid',
 'Dues Yr.'                => 'max_dues_year',
 'Dues Pd. Dt.'            => 'dues_paid_date',
 'Level'                   => 'level',
-'Scouting Reg.'           => 'bsa_reg',
-'Scouting Reg. Overidden' => 'bsa_reg_overridden',
-'Scouting Verify Date'    => 'bsa_verify_date',
-'Scouting Verify Status'  => 'bsa_verify_status',
+'Scouting Reg.'           => 'scouting_reg',
+'Scouting Reg. Overidden' => 'scouting_reg_overridden',
+'Scouting Verify Date'    => 'scouting_verify_date',
+'Scouting Verify Status'  => 'scouting_verify_status',
 );
 $complete = 0;
 $rowcount = $objWorksheet->getHighestRow();
@@ -102,7 +102,7 @@ foreach ($objWorksheet->getRowIterator() as $row) {
             $wpdb->show_errors();
             ob_start();
             # Make an empty temporary table based on the dues_data table
-            $wpdb->query("CREATE TEMPORARY TABLE {$dbprefix}dues_data_temp (PRIMARY KEY (bsaid)) SELECT * FROM {$dbprefix}dues_data LIMIT 0");
+            $wpdb->query("CREATE TEMPORARY TABLE {$dbprefix}dues_data_temp (PRIMARY KEY (memberid)) SELECT * FROM {$dbprefix}dues_data LIMIT 0");
             $oadueslookup_last_import = $wpdb->get_var("SELECT DATE_FORMAT(NOW(), '%Y-%m-%d')");
             # re-insert the test data
             oadueslookup_insert_sample_data();
@@ -120,7 +120,7 @@ foreach ($objWorksheet->getRowIterator() as $row) {
                 $dateint = intval($date);
                 $dateintVal = (int) $dateint;
                 $value = \PhpOffice\PhpSpreadsheet\Style\NumberFormat::toFormattedString($dateintVal, "YYYY-MM-DD");
-            } elseif ($columnName === "BSA Verify Date") {
+            } elseif ($columnName === "Scouting Verify Date") {
                 # this is also a date field, but can be empty
                 $date = $cell->getValue();
                 if (!$date) {
@@ -146,7 +146,7 @@ $error_output = ob_get_clean();
 ob_start();
 
 # NOTE: If you want to make all errors fatal, set the following to true.
-# Note that this will also make it fail when there are duplicate BSA IDs
+# Note that this will also make it fail when there are duplicate Member IDs
 # (which is why it's false by default).
 $treat_errors_as_fatal = false;
 

--- a/includes/dues-import.php
+++ b/includes/dues-import.php
@@ -68,7 +68,7 @@ function oadueslookup_import()
 
 <h3 class="oalm">Import data from OALM</h3>
 <p>Export file from OALM Must contain at least the following columns:<br>
-BSA ID, Dues Yr., Dues Pd. Dt., Level, BSA Reg., BSA Reg. Overidden, BSA Verify Date, BSA Verify Status<br>
+Member ID, Dues Yr., Dues Pd. Dt., Level, Scouting Reg., Scouting Reg. Overidden, Scouting Verify Date, Scouting Verify Status<br>
 Any additional columns will be ignored.</p>
 <p><a href="https://github.com/oabsa/dues-lookup/wiki/OALM-Export">How to create the export file in OALM</a></p>
 

--- a/includes/user-facing-lookup-page.php
+++ b/includes/user-facing-lookup-page.php
@@ -25,22 +25,22 @@ function oadueslookup_user_page($attr)
     $dbprefix = $wpdb->prefix . "oalm_";
 
     ob_start();
-    if (isset($_POST['bsaid'])) {
-        $bsaid = trim($_POST['bsaid']);
-        if (preg_match('/^\d+$/', $bsaid)) {
-            $results = $wpdb->get_row($wpdb->prepare("SELECT max_dues_year, dues_paid_date, level, bsa_reg, bsa_reg_overridden, bsa_verify_date, bsa_verify_status FROM {$dbprefix}dues_data WHERE bsaid = %d", array($bsaid)));
+    if (isset($_POST['memberid'])) {
+        $memberid = trim($_POST['memberid']);
+        if (preg_match('/^\d+$/', $memberid)) {
+            $results = $wpdb->get_row($wpdb->prepare("SELECT max_dues_year, dues_paid_date, level, scouting_reg, scouting_reg_overridden, scouting_verify_date, scouting_verify_status FROM {$dbprefix}dues_data WHERE memberid = %d", array($memberid)));
             if (!isset($results)) {
                 ?>
-<div class="oalm_dues_bad"><p>Your BSA Member ID <?php echo htmlspecialchars($bsaid) ?> was not found.</p></div>
+<div class="oalm_dues_bad"><p>Your Scouting Member ID <?php echo htmlspecialchars($memberid) ?> was not found.</p></div>
 <p>This can mean any of the following:</p>
 <ul>
 <li>You mistyped your ID</li>
 <li>You are not a member of the lodge.</li>
-<li><strong>(most likely)</strong> We don't have your BSA Member ID on your record or have the
+<li><strong>(most likely)</strong> We don't have your Scouting Member ID on your record or have the
 incorrect ID on your record.</li>
 </ul>
 <p><strong>NOTE:</strong> If you already made a payment more recently than <?php esc_html_e(get_option('oadueslookup_last_update')) ?> it is not yet reflected here.</p>
-<p>We currently have BSA Member IDs on file and verified as correctly matching your name
+<p>We currently have Scouting Member IDs on file and verified as correctly matching your name
 via the council records for everyone whose dues are current, so if your ID wasn't found
 and you're sure you typed it correctly, then your dues are not current, and you should
 pay them <a href="<?php echo get_option('oadueslookup_dues_url') ?>">here</a>.</p>
@@ -52,35 +52,35 @@ pay them <a href="<?php echo get_option('oadueslookup_dues_url') ?>">here</a>.</
                 $max_dues_year = $results->max_dues_year;
                 $dues_paid_date = $results->dues_paid_date;
                 $level = $results->level;
-                $bsa_reg = $results->bsa_reg ? "Registered" : "Not Registered";
-                $bsa_reg_overridden = $results->bsa_reg_overridden;
-                $bsa_reg_desc = $bsa_reg;
-                if ($bsa_reg_overridden) {
-                    $bsa_reg_desc = $bsa_reg_desc . " (overridden)";
+                $scouting_reg = $results->scouting_reg ? "Registered" : "Not Registered";
+                $scouting_reg_overridden = $results->scouting_reg_overridden;
+                $scouting_reg_desc = $scouting_reg;
+                if ($scouting_reg_overridden) {
+                    $scouting_reg_desc = $scouting_reg_desc . " (overridden)";
                 }
-                $bsa_verify_date = $results->bsa_verify_date;
-                $bsa_verify_status = $results->bsa_verify_status;
-                if ($bsa_verify_status == "") {
-                    $bsa_verify_status = "Never Run";
+                $scouting_verify_date = $results->scouting_verify_date;
+                $scouting_verify_status = $results->scouting_verify_status;
+                if ($scouting_verify_status == "") {
+                    $scouting_verify_status = "Never Run";
                 }
                 ?>
 <table class="oalm_dues_table">
-<tr><th>BSA Member ID</th><td class="oalm_value"><?php echo htmlspecialchars($bsaid) ?></td><td class="oalm_desc"></td></tr>
+<tr><th>Member ID</th><td class="oalm_value"><?php echo htmlspecialchars($memberid) ?></td><td class="oalm_desc"></td></tr>
 <tr><th>Dues Paid Thru</th><td class="oalm_value"><?php echo htmlspecialchars($max_dues_year) ?></td><td class="oalm_desc"><?php
                 $thedate = getdate();
 if ($max_dues_year >= $thedate['year']) {
     ?><span class="oalm_dues_good">Your dues are current.</span><?php
-if (($bsa_verify_status === "Never Run") || ($bsa_verify_status === "BSA ID Not Found") || ($bsa_verify_status === "BSA ID Found - Data Mismatch")) {
+if (($scouting_verify_status === "Never Run") || ($scouting_verify_status === "Member ID Not Found")) {
     ?><br><span class="oalm_dues_bad">However, your OA
                         membership is not currently valid because we could not
-                        verify your BSA Membership status (see
+                        verify your Scouting Membership status (see
                         below)</span><?php
 } elseif ($max_dues_year < get_option('oadueslookup_max_dues_year')) {
     ?><br><a href="<?php echo htmlspecialchars(get_option('oadueslookup_dues_url')) ?>">Click here to pay next year's dues online.</a><?php
 }
 } else {
     ?><span class="oalm_dues_bad">Your dues are not current.</span><?php
-if (($bsa_verify_status !== "Never Run") && ($bsa_verify_status !== "BSA ID Not Found") && ($bsa_verify_status !== "BSA ID Found - Data Mismatch")) {
+if (($scouting_verify_status !== "Never Run") && ($scouting_verify_status !== "Member ID Not Found")) {
     ?><br><a href="<?php echo htmlspecialchars(get_option('oadueslookup_dues_url')) ?>">Click here to pay your dues online.</a>
                             <p><strong>NOTE:</strong> If you already made a payment more recently than <?php esc_html_e(get_option('oadueslookup_last_update')) ?> it is not yet reflected here.</p><?php
 }
@@ -91,20 +91,20 @@ if (get_option('oadueslookup_dues_register') === "1") {
 ?></td></tr>
 <tr><th>Last Dues Payment</th><td class="oalm_value"><?php echo htmlspecialchars($dues_paid_date) ?></td><td class="oalm_desc"></td></tr>
 <tr><th>Your current honor/level</th><td class="oalm_value"><?php echo htmlspecialchars($level) ?></td><td class="oalm_desc"></td></tr>
-<tr><th>BSA Registration</th><td class="oalm_value"><?php echo htmlspecialchars($bsa_reg_desc) ?></td><td class="oalm_desc"></td></tr>
-<tr><th>BSA Verification Status</th><td class="oalm_value"><?php esc_html_e($bsa_verify_status) ?></td><td class="oalm_desc" style="text-align: left;"><?php
-if ($bsa_reg == "Registered") {
-    // Member is a registered BSA Member in good standing
+<tr><th>Scouting Registration</th><td class="oalm_value"><?php echo htmlspecialchars($scouting_reg_desc) ?></td><td class="oalm_desc"></td></tr>
+<tr><th>Scouting Verification Status</th><td class="oalm_value"><?php esc_html_e($scouting_verify_status) ?></td><td class="oalm_desc" style="text-align: left;"><?php
+if ($scouting_reg == "Registered") {
+    // Member is a registered Scouting America Member in good standing
     ?><span class="oalm_dues_good">You are currently an
                             active registered member of a Scouting unit.</span><br><?php
 } else {
-    switch ($bsa_verify_status) {
+    switch ($scouting_verify_status) {
         case "Member ID Verified":
-            ?><span class="oalm_dues_bad">Your BSA registration has
+            ?><span class="oalm_dues_bad">Your Scouting registration has
                             expired, which means you are no longer listed as an active
                             registered member of any Scouting unit, and therefore cannot
                             be a member of the OA.</span><br>You will need to reactivate
-                            your BSA membership by registering with a Scouting unit
+                            your Scouting membership by registering with a Scouting unit
                             (troop, pack, crew, district, etc.) before you may renew
                             your OA Membership. If you <strong>are</strong> currently a
                             member of a Scouting unit, please have your unit chairperson
@@ -113,45 +113,26 @@ if ($bsa_reg == "Registered") {
                             please check with all of them, as only the "primary"
                             unit counts, and it's not always clear which one is
                             primary.<br><br>We last checked your status in the
-                            BSA database on <?php esc_html_e($bsa_verify_date);
+                            Scouting database on <?php esc_html_e($scouting_verify_date);
             break;
         case "Member ID Not Found":
             ?><span class="oalm_dues_bad">Our most recent audit
-                            could not find you in the BSA database.</span><br>We
+                            could not find you in the Scouting database.</span><br>We
                             last attempted to find you on <?php
-                            esc_html_e($bsa_verify_date) ?>. If you
+                            esc_html_e($scouting_verify_date) ?>. If you
                             <strong>are</strong> currently a member of a Scouting unit,
                             please have your unit chairperson check to make sure
                             your registration has been properly submitted to the
                             council. If you are a member of more than one unit,
                             please check with all of them, as only the "primary"
                             unit counts, and it's not always clear which one is
-                            primary.<?php
-            break;
-        case "Member ID Found - Data Mismatch":
-            ?><span class="oalm_dues_bad">Your BSA registration exists
-                            in the BSA database, but one or more other data points do
-                            not match.</span><br><br>This means the information we have
-                            on file for you in the OA database does not match what is
-                            in the BSA database. Please check with your unit committee
-                            chairperson or advancement chairperson to verify how they
-                            have you listed on the unit roster. The items which matter
-                            are:<ol><li>the spelling, spacing, and punctuation of your last
-                            name,</li><li>your birth date,</li><li>your gender,
-                            and</li><li>your BSA Member ID.</li></ol>Once you've
-                            verified this information, please submit it to us by using the
-                            "<?php echo htmlspecialchars(get_option('oadueslookup_update_option_text')) ?>"
-                            option on the
-                            <a href="<?php echo htmlspecialchars(get_option('oadueslookup_update_url')) ?>">
-                <?php echo htmlspecialchars(get_option('oadueslookup_update_option_link_text')) ?>
-                            </a>
-                            <?php
+                            primary. <?php
             break;
         case "Never Run":
             ?>This means one of the following things:<ul>
                             <li>You're new, and we haven't run a new audit against
-                            the BSA database since you were put in the OA
-                            database</li> <li>Your BSA Member ID was just recently
+                            the Scouting database since you were put in the OA
+                            database</li> <li>Your Scouting Member ID was just recently
                             added to the OA database, and a new audit hasn't been
                             run yet.</li> <li>You haven't paid dues in over 3
                             years, so we didn't include you in the audit because we
@@ -165,28 +146,28 @@ if ($bsa_reg == "Registered") {
             ?><br><p>Feel free to contact <a href="mailto:<?php echo htmlspecialchars(get_option('oadueslookup_help_email')) ?>?subject=Dues+question"><?php echo htmlspecialchars(get_option('oadueslookup_help_email')) ?></a> with any questions.</p>
 <p><strong>Database last updated:</strong> <?php esc_html_e(get_option('oadueslookup_last_update')) ?></p>
 <br><br>
-<p>Check another BSA Member ID:</p>
+<p>Check another Scouting Member ID:</p>
 <form method="POST" action="">
-<label for="bsaid">BSA Member ID:</label> <input id="bsaid" name="bsaid" type="text" size="9">
+<label for="memberid">Scouting Member ID:</label> <input id="memberid" name="memberid" type="text" size="9">
 <input type="submit" value="Go">
 </form>
             <?php
         } else {
             ?>
-<div class="oalm_dues_bad"><p>Invalid BSA Member ID entered, please try again.</p></div>
+<div class="oalm_dues_bad"><p>Invalid Scouting Member ID entered, please try again.</p></div>
             <?php
         }
         ?>
         <?php
     } else {
         ?>
-<p>Enter your BSA Member ID to check your current dues status or <a href="<?php echo htmlspecialchars(get_option('oadueslookup_dues_url')) ?>">pay your dues</a>.</p>
+<p>Enter your Scouting Member ID to check your current dues status or <a href="<?php echo htmlspecialchars(get_option('oadueslookup_dues_url')) ?>">pay your dues</a>.</p>
 <form method="POST" action="">
-<label for="bsaid">BSA Member ID:</label> <input id="bsaid" name="bsaid" type="text" size="9">
+<label for="memberid">Scouting Member ID:</label> <input id="memberid" name="memberid" type="text" size="9">
 <input type="submit" value="Go">
 </form>
 <br>
-<p>You can find your Member ID at the bottom of your blue BSA Membership card:</p>
+<p>You can find your Member ID at the bottom of your blue Scouting Membership card:</p>
 <p><img src="<?php echo plugins_url("../BSAMemberCard.png", __FILE__) ?>" alt="Membership Card" style="border: 1px solid #ccc;"></p>
 <p>If you can't find your membership card, your unit committee chairperson should be able to look it up on your unit recharter document, or your advancement chairperson can look it up in the Online Advancement System.</p>
 <p>If you just came here to update your contact information, <a href="<?php echo htmlspecialchars(get_option('oadueslookup_update_url')) ?>">click here</a>.</p>

--- a/oadueslookup.php
+++ b/oadueslookup.php
@@ -47,7 +47,7 @@ function oadueslookup_enqueue_css()
 }
 
 global $oadueslookup_db_version;
-$oadueslookup_db_version = 3;
+$oadueslookup_db_version = 4;
 
 function oadueslookup_create_table($ddl)
 {
@@ -93,15 +93,15 @@ function oadueslookup_install()
     // change it'll need update code (see below).
 
     $sql = "CREATE TABLE {$dbprefix}dues_data (
-  bsaid                 INT NOT NULL,
-  max_dues_year         VARCHAR(4),
-  dues_paid_date        DATE,
-  level                 VARCHAR(12),
-  bsa_reg               TINYINT(1),
-  bsa_reg_overridden    TINYINT(1),
-  bsa_verify_date       DATE,
-  bsa_verify_status     VARCHAR(50),
-  PRIMARY KEY (bsaid)
+  memberid                 INT NOT NULL,
+  max_dues_year            VARCHAR(4),
+  dues_paid_date           DATE,
+  level                    VARCHAR(12),
+  scouting_reg             TINYINT(1),
+  scouting_reg_overridden  TINYINT(1),
+  scouting_verify_date     DATE,
+  scouting_verify_status   VARCHAR(50),
+  PRIMARY KEY (memberid)
 );";
     oadueslookup_create_table($sql);
 
@@ -141,6 +141,16 @@ function oadueslookup_install()
         $wpdb->query("ALTER TABLE {$dbprefix}dues_data ADD COLUMN bsa_reg_overridden TINYINT(1)");
         $wpdb->query("ALTER TABLE {$dbprefix}dues_data ADD COLUMN bsa_verify_date DATE");
         $wpdb->query("ALTER TABLE {$dbprefix}dues_data ADD COLUMN bsa_verify_status VARCHAR(50)");
+    }
+
+    if ($installed_version < 4) {
+        # BSA became Scouting America, so change the column names appropriately
+        $wpdb->query("ALTER TABLE `{$dbprefix}dues_data` " .
+            "CHANGE COLUMN `bsaid` `memberid` INT NOT NULL , " .
+            "CHANGE COLUMN `bsa_reg` `scouting_reg` TINYINT(1) NULL DEFAULT NULL , " .
+            "CHANGE COLUMN `bsa_reg_overridden` `scouting_reg_overridden` TINYINT(1) NULL DEFAULT NULL , " .
+            "CHANGE COLUMN `bsa_verify_date` `scouting_verify_date` DATE NULL DEFAULT NULL , " .
+            "CHANGE COLUMN `bsa_verify_status` `scouting_verify_status` VARCHAR(50) NULL DEFAULT NULL");
     }
 
     // insert next database revision update code immediately above this line.
@@ -223,7 +233,7 @@ function oadueslookup_insert_sample_data()
     $dbprefix = $wpdb->prefix . "oalm_";
 
     $wpdb->query("INSERT INTO {$dbprefix}dues_data_temp " .
-        "(bsaid,    max_dues_year, dues_paid_date, level,        bsa_reg,   bsa_reg_overridden, bsa_verify_date, bsa_verify_status) VALUES " .
+        "(memberid,    max_dues_year, dues_paid_date, level,        scouting_reg,   scouting_reg_overridden, scouting_verify_date, scouting_verify_status) VALUES " .
         "('123453','2013',         '2012-11-15',   'Brotherhood','1',       '0',                '1900-01-01',   'Member ID Not Found'), " .
         "('123454','2014',         '2013-12-28',   'Ordeal',     '1',       '0',                '1900-01-01',   'Member ID Not Found'), " .
         "('123455','2014',         '2013-12-28',   'Brotherhood','1',       '0',                '1900-01-01',   'Member ID Verified'), " .
@@ -231,7 +241,7 @@ function oadueslookup_insert_sample_data()
         "('123457','2014',         '2013-12-18',   'Brotherhood','0',       '0',                '1900-01-01',   'Member ID Found - Data Mismatch'), " .
         "('123458','2013',         '2013-03-15',   'Vigil',      '1',       '0',                '1900-01-01',   'Member ID Not Found'), " .
         "('123459','2015',         '2014-03-15',   'Ordeal',     '0',       '0',                '1900-01-01',   'Never Run')");
-    $wpdb->query($wpdb->prepare("UPDATE {$dbprefix}dues_data SET bsa_verify_date=%s", get_option('oadueslookup_last_update')));
+    $wpdb->query($wpdb->prepare("UPDATE {$dbprefix}dues_data SET scouting_verify_date=%s", get_option('oadueslookup_last_update')));
 }
 
 function oadueslookup_install_data()


### PR DESCRIPTION
* Full rebrand to the new Scouting America terminology.
* The included membership card sample is still the old one because the one I can download from MyScouting still says BSA on it. As soon as they update it, I'll update the sample graphic.